### PR TITLE
Sidecolour plots and re-organisation of subplot code

### DIFF
--- a/R/heatmaply.R
+++ b/R/heatmaply.R
@@ -545,12 +545,12 @@ heatmaply.heatmapr <- function(x,
   if (missing(row_side_colours)) pr <- NULL
   else {
     pr <- side_colour_plot(row_side_colours, type = "row",
-      palette = row_side_palette, ...)
+      palette = row_side_palette)
   }
   if (missing(col_side_colours)) pc <- NULL
   else {
     pc <- side_colour_plot(col_side_colours, type = "column",
-      palette = col_side_palette, ...)
+      palette = col_side_palette)
   }
   ## plotly:
   # turn p, px, and py to plotly objects
@@ -670,28 +670,15 @@ if(FALSE) {
 
 
 
-
-
-
-
-
-
-
-
-
-
-side_colour_plot <- function(df, id_var, palette = viridis,
+side_colour_plot <- function(df, palette = viridis,
   scale_title = paste(type, "side colours"), type = c("column", "row")) {
+  
   type <- match.arg(type)
-  if (missing(id_var)) {
-    ## Assume that it is molten already
-    if (!all(c("value", "variable") %in% colnames(df))) {
-      stop("`df` doesn't seem to be molten and id_var has not been supplied!")
-    }
-    id_var <- colnames(df)[1]
-  } else {
-    df <- reshape2::melt(df, id.vars = id_var)
+  
+  if (!all(c("value", "variable") %in% colnames(df))) {
+    stop("`df` doesn't seem to be molten and id_var has not been supplied!")
   }
+  id_var <- colnames(df)[1]
   if (type == "column") {
     mapping <- aes_string(x=id_var, y='variable', fill='value')
     theme <- theme(

--- a/R/heatmaply.R
+++ b/R/heatmaply.R
@@ -57,6 +57,7 @@
 #' @param titleX logical (TRUE). should x-axis titles be retained? (passed to \link[plotly]{subplot}).
 #' @param titleY logical (TRUE). should y-axis titles be retained? (passed to \link[plotly]{subplot}).
 #'
+#' 
 #' @param hide_colorbar logical (FALSE). If TRUE, then the color bar is hidden.
 #'
 #' @param key.title (character) main title of the color key. If set to NULL (default) no title will be plotted.
@@ -65,6 +66,17 @@
 #' returned (before turning into plotly objects). This is a temporary option which might be removed in the
 #' future just to make it easy to create a ggplot heatmaps.
 #'
+#' @param row_side_colors,col_side_colors data.frame of factors to produce 
+#'    row/column side colors in the style of heatmap.2/heatmap.3. 
+#'    col_side_colors should be "wide", ie be the same dimensions 
+#'    as the column side colors it will produce.
+#' 
+#' @param row_side_palette,col_side_palette Color palette functions to be 
+#'    used for row_side_colors and col_side_colors respectively. 
+#' 
+#' @param hatmap_layers ggplot object (eg, theme_bw()) to be added to 
+#'  the heatmap before conversion to a plotly object.
+#' 
 #' Please submit an issue on github if you have a feature that you wish to have added)
 #' @aliases
 #' heatmaply.default

--- a/R/heatmapr.R
+++ b/R/heatmapr.R
@@ -72,6 +72,11 @@
 #' @param labRow character vectors with row labels to use (from top to bottom); default to rownames(x).
 #' @param labCol character vectors with column labels to use (from left to right); default to colnames(x).
 #'
+#' @param row_side_colors,col_side_colors data.frame of factors to produce 
+#'    row/column side colors in the style of heatmap.2/heatmap.3. 
+#'    col_side_colors should be "wide", ie be the same dimensions 
+#'    as the column side colors it will produce.
+#' 
 #' @param seriate character indicating the method of matrix sorting (default: "OLO").
 #' Implemented options include:
 #' "OLO" (Optimal leaf ordering, optimzes the Hamiltonian path length that is restricted by the dendrogram structure - works in O(n^4) )

--- a/R/heatmapr.R
+++ b/R/heatmapr.R
@@ -135,8 +135,10 @@ heatmapr <- function(x,
                       brush_color = "#0000FF",
                       show_grid = TRUE,
                       anim_duration = 500,
-
-                     seriate = c("OLO", "mean", "none", "GW"),
+                      
+                      row_side_colors = NULL,
+                      col_side_colors = NULL,
+                      seriate = c("OLO", "mean", "none", "GW"),
 
                       ...
 ) {
@@ -302,10 +304,12 @@ heatmapr <- function(x,
 
   ## reorder x (and others)
   ##=======================
-  x <- x[rowInd, colInd]
+  x <- x[rowInd, colInd, drop = FALSE]
   if (!missing(cellnote))
-    cellnote <- cellnote[rowInd, colInd]
+    cellnote <- cellnote[rowInd, colInd, drop = FALSE]
 
+  if (!is.null(row_side_colors)) row_side_colors <- row_side_colors[rowInd, ]
+  if (!is.null(col_side_colors)) col_side_colors <- col_side_colors[, colInd] 
 
   ## Dendrograms - Update the labels and change to dendToTree
   ##=======================
@@ -408,7 +412,9 @@ heatmapr <- function(x,
   }
 
   heatmapr <- list(rows = rowDend, cols = colDend, matrix = mtx, # image = imgUri,
-                  theme = theme, options = options)
+                  theme = theme, options = options,
+                  row_side_colors = row_side_colors,
+                  col_side_colors = col_side_colors)
 
   class(heatmapr) <- "heatmapr"
 


### PR DESCRIPTION
I ended up using a different method to deal with the presence/absence of rowsidecolors/colsidecolors, row/column dendrogram. It should deal with all possibilities and be extensible/maintainable with a minimum of code duplication

One possible issue is that currently I have passed row/col_side_colors into heatmapr to deal with the re-ordering that occurs during hierarchical clustering. It might be preferable to return `colInd` and `rowInd` from heatmapr to avoid having one re-ordered and one original version of these in the environment.

I have tried to remain consistent in my use of `color` as opposed to `colour` but please flag up any times I've missed that as I think consistency in this is important within a package