### PR TITLE
Fix typo on README.md showing how to install dev prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ To install the latest ("cutting-edge") GitHub version run:
 
 # good packages to install for this to work smoothly:
 
-install.packages("Rcpp", "ggplot2","munsell","htmltools","DBI","assertthat","gridExtra",
-'devtools',"fpc","TSP","registry","gclus","gplots","RColorBrewer",
-"stringr","labeling","yaml")
+install.packages(c("Rcpp","ggplot2","munsell","htmltools","DBI","assertthat",
+"gridExtra",'devtools',"fpc","TSP","registry","gclus","gplots","RColorBrewer",
+"stringr","labeling","yaml"))
 
 # You'll need devtools
 install.packages.2 <- function (pkg) if (!require(pkg)) install.packages(pkg);

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To install the latest ("cutting-edge") GitHub version run:
 # good packages to install for this to work smoothly:
 
 install.packages(c("Rcpp","ggplot2","munsell","htmltools","DBI","assertthat",
-"gridExtra",'devtools',"fpc","TSP","registry","gclus","gplots","RColorBrewer",
+"gridExtra","digest","fpc","TSP","registry","gclus","gplots","RColorBrewer",
 "stringr","labeling","yaml"))
 
 # You'll need devtools


### PR DESCRIPTION
Original didn't combine package names into a vector.