### PR TITLE
ggheatmap: hide_colorbar and widths options

### DIFF
--- a/R/ggheatmap.R
+++ b/R/ggheatmap.R
@@ -76,10 +76,14 @@ arrange_plots <- function(
   ind_remove_row <- rep(ind_null_row, length.out = length(plotlist))
   plotlist <- plotlist[!(ind_remove_row | ind_remove_col)]
 
+  widths <- widths %||% default_dims(plots$px, plots$pr)
+  if (row_dend_left) {
+    widths <- rev(widths)
+  }
   egg::ggarrange(
     plots = plotlist,
     ncol = ncols,
-    widths = widths %||% default_dims(plots$px, plots$pr),
+    widths = widths,
     heights = heights %||% rev(default_dims(plots$py, plots$pc))
   )
 }


### PR DESCRIPTION
Thanks for the great package. 

When I used the ggheatmap function, I realize 'hide_colorbar' is not working. I checked the sources and found that the main heatmaply function applies 'hide_colorbar' option only to 'plotly' object. To resolve the issue, I added 'hide_colorbar' argument to the arrange_plots function and made a heatmap hide its legend by setting theme(legend.position = "none") if hide_colorbar = TRUE. 

Another small modification was to reverse default widths if row_dend_left = TRUE in the arrange_plots as implemented in the heatmap_subplot_from_ggplotly function.