### PR TITLE
Leave annotation names without adding dots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Imports:
     htmlwidgets,
     webshot,
     assertthat,
-    egg
+    egg,
+    tibble
 Suggests:
     knitr,
     covr,

--- a/R/heatmaply.R
+++ b/R/heatmaply.R
@@ -668,9 +668,9 @@ heatmaply.default <- function(x,
   # TODO: add a parameter to control removing of non-numeric columns without moving them to row_side_colors
   if (!all(ss_c_numeric)) {
     row_side_colors <- if (is.null(row_side_colors)) {
-      data.frame(x[, !ss_c_numeric, drop = FALSE])
+      tibble::tibble(x[, !ss_c_numeric, drop = FALSE])
     } else {
-      data.frame(row_side_colors, x[, !ss_c_numeric, drop = FALSE])
+      tibble::tibble(row_side_colors, x[, !ss_c_numeric, drop = FALSE])
     }
     x <- x[, ss_c_numeric]
   }


### PR DESCRIPTION
```
x = mtcars %>% mutate(`Annot 1` = as.character(cyl)
heatmaply(x)
```
This shows the annotation as `Annot.1` because of the conversion to a data.frame(). Switching to using tibble() fixes this, albeit add the {tibble} dependency.