### PR TITLE
Hide row dendrogram axis ticks for plotly

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -357,12 +357,14 @@ plotly_dend <- function(dend,
     title = "",
     range = c(0, max(segs$y)),
     linecolor = "#ffffff",
+    showticklabels = FALSE,
     showgrid = FALSE
   )
   axis2 <- list(
     title = "",
     range = c(0, lab_max),
     linecolor = "#ffffff",
+    showticklabels = FALSE,
     showgrid = FALSE
   )
 


### PR DESCRIPTION
To reproduce the issue, run:

```
heatmaply::heatmaply(mtcars, dendrogram = "row", plot_method = "plotly")
```

Notice that the row dendrogram has axis ticks at the bottom.

This issue is not present when plot_method is not `plotly`, or when dendrogram is not `row`. I have not looked into why this is the case.